### PR TITLE
Increase of cinfo size to 64 bits

### DIFF
--- a/constable/generic.c
+++ b/constable/generic.c
@@ -29,7 +29,7 @@ int generic_set_handler( struct class_handler_s *h, struct comm_s *comm, struct 
 { 
     struct tree_s *t; // ,*p; unused
     int a,inh;
-    uint32_t *cinfo; // changed from uintptr_t* to void** // should be uint32_t instead uintptr_t, by Matus
+    uint64_t *cinfo; // 64-bit size because a pointer will be stored here
     /* musim get_tree_node robit sam, aby sa nezacyklilo */
     cinfo=PCINFO(o,h,comm);
 
@@ -92,7 +92,7 @@ int generic_test_vs_tree( int acctype, struct event_context_s *c, struct tree_s 
 }
 
 int generic_hierarchy_handler_decide( struct comm_buffer_s *cb, struct event_handler_s *h, struct event_context_s *c )
-{ uint32_t *cinfo;  // should be uint32_t instead uintptr_t, by Matus
+{ uint64_t *cinfo;  // 64-bit size because a pointer will be stored here
     struct tree_s *t;
     char *n;
     int r;
@@ -110,7 +110,7 @@ int generic_hierarchy_handler_decide( struct comm_buffer_s *cb, struct event_han
             t= (struct tree_s *)CINFO(&(c->object),ch,cb->comm);
         if( t==NULL )
             t=ch->root;
-        *cinfo=(uint32_t)t; // should be uint32_t instead uintptr_t, by Matus
+        *cinfo=(uint64_t)t; // 64-bit size because a pointer will be stored here
         object_do_sethandler(&(c->subject));
     }
     printf("ZZZ: riesim generic_hierarchy_handler pre %s\n",t->type->name);
@@ -163,7 +163,7 @@ int generic_hierarchy_handler_decide( struct comm_buffer_s *cb, struct event_han
 }
 
 int generic_hierarchy_handler_notify( struct comm_buffer_s *cb, struct event_handler_s *h, struct event_context_s *c )
-{ uint32_t *cinfo;  // should be uint32_t instead uintptr_t, by Matus
+{ uint64_t *cinfo;  // 64-bit size because a pointer will be stored here
     struct class_handler_s *ch;
 
     ch=((struct g_event_handler_s*)h)->class_handler;

--- a/constable/object.h
+++ b/constable/object.h
@@ -92,7 +92,7 @@ int class_add_handler( struct class_names_s *c, struct class_handler_s *handler 
 
 int class_comm_init( struct comm_s *comm );
 
-#define	PCINFO(object,ch,comm)	((uint32_t*)((object)->data+(ch)->cinfo_offset[(comm)->conn])) // should be uint32_t instead uintptr_t, by Matus
+#define	PCINFO(object,ch,comm)	((uint64_t*)((object)->data+(ch)->cinfo_offset[(comm)->conn])) // 64-bit size because a pointer will be stored here
 #define	CINFO(object,ch,comm)	(*(PCINFO(object,ch,comm)))
 
 int object_get_val( struct object_s *o, struct medusa_attribute_s *a, void *buf, int maxlen );


### PR DESCRIPTION
## Summary
Constable stores its pointers in cinfo variable. Since these pointers are
64-bit on 64-bit systems, the type of the variable had to be changed.

## Backstory
New version of gcc compiler (6.3.0) compiles Constable with higher addresses than before. Thus Constable signaled segfault whenever it wanted to access truncated 64-bit address that didn't belong to its address space. This commit corrects that behavior.

## Note
Change in Medusa was also needed. More information in [this commit](https://github.com/Medusa-Team/linux-medusa/commit/2bd83ed95263dc87d30e081a54c271258bdddcd8).